### PR TITLE
Update for modern Swift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-XCODE = $(shell xcode-select -p)
 VERSION = 2
 LIBRARY_NAME = pam_touchid.so
 DESTINATION = /usr/local/lib/pam
 TARGET = x86_64-apple-macosx10.12.3
 
 all:
-	$(XCODE)/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc touchid-pam-extension.swift -o $(LIBRARY_NAME) -target $(TARGET) -emit-library -sdk $(XCODE)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -static-stdlib
+	swiftc touchid-pam-extension.swift -o $(LIBRARY_NAME) -target $(TARGET) -emit-library -static-stdlib
 
 install: all
 	mkdir -p $(DESTINATION)

--- a/touchid-pam-extension.swift
+++ b/touchid-pam-extension.swift
@@ -46,7 +46,7 @@ private func parseArguments(argc: Int, argv: vchar) -> [String: String] {
                                          options: .dotMatchesLineSeparators)
 
     let matches = regex?.matches(in: arguments, options: .withoutAnchoringBounds,
-                                 range: NSRange(location: 0, length: arguments.characters.count))
+                                 range: NSRange(location: 0, length: arguments.count))
 
     let nsArguments = arguments as NSString
     let groups = matches?


### PR DESCRIPTION
There was only 1 syntax change here. This also removes some unnecessary
Makefile configuration that made the build fail with newer versions of
Xcode.