### PR TITLE
Ignore if `-A`/`—askpass` is set.

### DIFF
--- a/touchid-pam-extension.swift
+++ b/touchid-pam-extension.swift
@@ -14,6 +14,11 @@ public typealias pam_handler_t = UnsafeRawPointer
 
 @_silgen_name("pam_sm_authenticate")
 public func pam_sm_authenticate(pamh: pam_handler_t, flags: Int, argc: Int, argv: vchar) -> Int {
+    let sudoArguments = ProcessInfo.processInfo.arguments
+    if sudoArguments.contains("-A") || sudoArguments.contains("--askpass") {
+        return PAM_IGNORE
+    }
+
     let arguments = parseArguments(argc: argc, argv: argv)
     var reason = arguments["reason"] ?? DEFAULT_REASON
     reason = reason.isEmpty ? DEFAULT_REASON : reason


### PR DESCRIPTION
When running a script which uses `SUDO_ASKPASS`, it still prompts for a fingerprint, even though the password should be read from the script given by `SUDO_ASKPASS`. This change ignores the fingerprint if the `-A/--askpass` argument is given.