### PR TITLE
Update makefile to support Big Sur with/-out Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
 VERSION = 2
 LIBRARY_NAME = pam_touchid.so
 DESTINATION = /usr/local/lib/pam
-TARGET = x86_64-apple-macosx10.12.3
+ARCH := $(shell uname -m)
+ifeq ($(ARCH), arm64)
+TARGET := arm64-apple-darwin20.1.0
+else
+TARGET := x86_64-apple-darwin20.1.0
+endif
 
-all:
+.PHONY: all
+
+all: $(LIBRARY_NAME)
+
+$(LIBRARY_NAME): touchid-pam-extension.swift
 	swiftc touchid-pam-extension.swift -o $(LIBRARY_NAME) -target $(TARGET) -emit-library
 
-install: all
+install: $(LIBRARY_NAME)
 	mkdir -p $(DESTINATION)
-	rm -f $(DESTINATION)/$(LIBRARY_NAME).$(VERSION)
-	cp $(LIBRARY_NAME) $(DESTINATION)/$(LIBRARY_NAME).$(VERSION)
-	chmod 444 $(DESTINATION)/$(LIBRARY_NAME).$(VERSION)
-	sudo chown root:wheel $(DESTINATION)/$(LIBRARY_NAME).$(VERSION)
+	install -b -o root -g wheel -m 444 $(LIBRARY_NAME) $(DESTINATION)/$(LIBRARY_NAME).$(VERSION)


### PR DESCRIPTION
* Update target to `apple-darwin20.1.0`
* Auto-detect arch to select target `arm64-apple-darwin20.1.0` or `x86_64-apple-darwin20.1.0`, can be override with `make TARGET=<target>` option
* use `install` command to ensure permissions during the installation

Fixed #16 
Fixed #17